### PR TITLE
Scope loterie overlay to thumbnails

### DIFF
--- a/wp-content/plugins/loterie-manager/assets/css/frontend.css
+++ b/wp-content/plugins/loterie-manager/assets/css/frontend.css
@@ -1,11 +1,29 @@
-.lm-loterie-overlay {
+.lm-loterie-thumbnail {
     position: relative;
-    background: rgba(0, 0, 0, 0.7);
+    display: block;
+    overflow: hidden;
+    border-radius: 6px;
+}
+
+.lm-loterie-thumbnail > img,
+.lm-loterie-thumbnail .wp-post-image {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+
+.lm-loterie-thumbnail .lm-loterie-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    background: linear-gradient(0deg, rgba(0, 0, 0, 0.85) 0%, rgba(0, 0, 0, 0.25) 60%, rgba(0, 0, 0, 0) 100%);
     color: #fff;
     padding: 1rem;
-    margin-bottom: 1rem;
-    border-radius: 6px;
-    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+    box-shadow: none;
+    pointer-events: none;
+    border-radius: inherit;
 }
 
 .lm-overlay-header {


### PR DESCRIPTION
## Summary
- scope the loterie overlay injection to the post thumbnail HTML instead of post content and skip singular views
- wrap featured images with an overlay container when appropriate using a helper for markup generation
- update frontend styles to target the new thumbnail container without affecting global layout

## Testing
- php -l wp-content/plugins/loterie-manager/loterie-manager.php

------
https://chatgpt.com/codex/tasks/task_e_68cc58791bd083299edd85b1995989d8