### PR TITLE
Enhance lottery shortcode card presentation

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -149,3 +149,290 @@
 .lm-ticket-table th {
     background: #fafafa;
 }
+:root {
+    --winshirt-purple: #7c3aed;
+    --winshirt-blue: #2563eb;
+    --lm-card-bg: rgba(255, 255, 255, 0.05);
+    --lm-card-border: rgba(255, 255, 255, 0.1);
+    --lm-card-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
+    --lm-muted: rgba(255, 255, 255, 0.3);
+    --lm-accent: #22d3ee;
+}
+
+.tilt-card {
+    position: relative;
+    display: block;
+    border-radius: 1rem;
+    cursor: pointer;
+    overflow: hidden;
+    transition: box-shadow 0.2s ease;
+    transform-style: preserve-3d;
+    transform: perspective(1000px);
+    box-shadow: var(--lm-card-shadow);
+    will-change: transform;
+    background: var(--lm-card-bg);
+    border: 1px solid var(--lm-card-border);
+    color: #ffffff;
+    isolation: isolate;
+}
+
+.tilt-card:hover {
+    box-shadow: 0 10px 40px rgba(10, 10, 45, 0.45);
+}
+
+.tilt-card::before {
+    content: '';
+    position: absolute;
+    inset: -140% -60%;
+    background: linear-gradient(120deg, transparent 40%, rgba(0, 255, 255, 0.18) 48%, rgba(255, 255, 255, 0.25) 52%, transparent 60%);
+    opacity: 0;
+    transform: translateY(-100%) scale(1);
+    transition: opacity 0.45s ease, transform 0.45s ease;
+    pointer-events: none;
+    z-index: 2;
+}
+
+.tilt-card.flash::before {
+    opacity: 1;
+    transform: translateY(100%) scale(1.05);
+}
+
+.tilt-card__inner {
+    position: relative;
+    height: 100%;
+    transform-style: preserve-3d;
+}
+
+.lm-lottery-card {
+    background: var(--lm-card-bg);
+}
+
+.lm-lottery-card__media {
+    position: relative;
+    overflow: hidden;
+    border-radius: inherit;
+}
+
+.lm-lottery-card__media-ratio {
+    position: relative;
+    width: 100%;
+    padding-top: 56.25%;
+}
+
+.lm-lottery-card__image,
+.lm-lottery-card__placeholder {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transform: translate(-50%, -50%);
+}
+
+.lm-lottery-card__placeholder {
+    background: radial-gradient(circle at 30% 20%, rgba(124, 58, 237, 0.45), transparent 60%),
+        radial-gradient(circle at 70% 80%, rgba(34, 211, 238, 0.4), transparent 55%),
+        #1f2937;
+}
+
+.lm-lottery-card__gradient {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to top, rgba(0, 0, 0, 0.85), transparent);
+    z-index: 1;
+    pointer-events: none;
+}
+
+.lm-lottery-card__badge {
+    position: absolute;
+    top: 0.75rem;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    backdrop-filter: blur(6px);
+    z-index: 3;
+    color: #ffffff;
+    line-height: 1.4;
+}
+
+.lm-lottery-card__badge--status {
+    left: 0.75rem;
+}
+
+.lm-lottery-card__badge--status.is-active {
+    background: rgba(34, 197, 94, 0.7);
+}
+
+.lm-lottery-card__badge--status.is-ended {
+    background: rgba(107, 114, 128, 0.7);
+}
+
+.lm-lottery-card__badge--featured {
+    right: 0.75rem;
+    background: rgba(124, 58, 237, 0.7);
+}
+
+.lm-lottery-card__info {
+    position: absolute;
+    inset: auto 0 0 0;
+    padding: 1.5rem 1.25rem 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    z-index: 3;
+}
+
+.lm-lottery-card__title {
+    margin: 0;
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: #ffffff;
+}
+
+.lm-lottery-card__value {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #ffffff;
+}
+
+.lm-lottery-card__countdown {
+    display: flex;
+    gap: 0.5rem;
+    color: #ffffff;
+}
+
+.lm-lottery-card__countdown-box {
+    background: rgba(0, 0, 0, 0.4);
+    backdrop-filter: blur(6px);
+    padding: 0.35rem 0.6rem;
+    border-radius: 0.6rem;
+    text-align: center;
+    min-width: 3rem;
+}
+
+.lm-lottery-card__countdown-value {
+    font-size: 1.05rem;
+    font-weight: 700;
+    line-height: 1.25;
+}
+
+.lm-lottery-card__countdown-label {
+    font-size: 0.65rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.lm-lottery-card__meta {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    color: #ffffff;
+}
+
+.lm-lottery-card__meta-icon {
+    flex-shrink: 0;
+    color: var(--winshirt-purple);
+}
+
+.lm-lottery-card__goal {
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.progress-bar {
+    position: relative;
+    width: 100%;
+    height: 8px;
+    border-radius: 999px;
+    overflow: hidden;
+    background: var(--lm-muted);
+}
+
+.progress-bar-fill {
+    display: block;
+    height: 100%;
+    background: var(--lm-accent);
+    border-radius: inherit;
+    transition: width 0.3s ease;
+}
+
+.lm-lottery-card__footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.85rem 1.1rem;
+    background: rgba(15, 23, 42, 0.55);
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(12px);
+}
+
+.lm-lottery-card__footer-date {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+}
+
+.lm-lottery-card__footer-icon {
+    color: var(--winshirt-blue);
+}
+
+.lm-lottery-card__cta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.4rem 1rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    background: rgba(124, 58, 237, 0.2);
+    color: #ffffff;
+    text-decoration: none;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.lm-lottery-card__cta:hover,
+.lm-lottery-card__cta:focus {
+    background: rgba(124, 58, 237, 0.4);
+    color: #ffffff;
+}
+
+.lm-lottery-card--featured {
+    min-height: 100%;
+}
+
+@media (min-width: 768px) {
+    .lm-lottery-card--featured {
+        grid-column: span 2;
+        grid-row: span 2;
+    }
+}
+
+@media (max-width: 640px) {
+    .lm-lottery-card__info {
+        padding: 1.1rem 1rem 1rem;
+        gap: 0.6rem;
+    }
+
+    .lm-lottery-card__title {
+        font-size: 1.25rem;
+    }
+
+    .lm-lottery-card__countdown {
+        gap: 0.4rem;
+    }
+
+    .lm-lottery-card__countdown-box {
+        min-width: 2.6rem;
+        padding: 0.3rem 0.45rem;
+    }
+}
+

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -185,4 +185,76 @@
             pendingForm = null;
         }
     });
+
+    function initTiltCards() {
+        var hoverMedia = window.matchMedia ? window.matchMedia('(hover: hover)') : null;
+        if (hoverMedia && !hoverMedia.matches) {
+            return;
+        }
+
+        var cards = document.querySelectorAll('.tilt-card');
+        if (!cards.length) {
+            return;
+        }
+
+        cards.forEach(function (card) {
+            var target = { x: 0, y: 0 };
+            var current = { x: 0, y: 0 };
+            var raf = null;
+
+            function animate() {
+                current.x += (target.x - current.x) * 0.12;
+                current.y += (target.y - current.y) * 0.12;
+
+                card.style.transform = 'perspective(1000px) rotateY(' + current.x.toFixed(2) + 'deg) rotateX(' + current.y.toFixed(2) + 'deg) scale3d(1.04,1.04,1)';
+
+                if (Math.abs(current.x - target.x) < 0.05 && Math.abs(current.y - target.y) < 0.05) {
+                    current.x = target.x;
+                    current.y = target.y;
+                    if (target.x === 0 && target.y === 0) {
+                        card.style.transform = 'perspective(1000px)';
+                    }
+                    raf = null;
+                    return;
+                }
+
+                raf = window.requestAnimationFrame(animate);
+            }
+
+            function setTarget(normX, normY) {
+                target.x = Math.max(-1, Math.min(1, normX)) * 18;
+                target.y = Math.max(-1, Math.min(1, -normY)) * 18;
+                if (!raf) {
+                    raf = window.requestAnimationFrame(animate);
+                }
+            }
+
+            card.addEventListener('mousemove', function (event) {
+                var rect = card.getBoundingClientRect();
+                var offsetX = event.clientX - rect.left;
+                var offsetY = event.clientY - rect.top;
+                var normX = (offsetX / rect.width) * 2 - 1;
+                var normY = (offsetY / rect.height) * 2 - 1;
+                setTarget(normX, normY);
+            });
+
+            card.addEventListener('mouseenter', function () {
+                setTarget(0, 0);
+                card.classList.add('flash');
+                window.setTimeout(function () {
+                    card.classList.remove('flash');
+                }, 600);
+            });
+
+            card.addEventListener('mouseleave', function () {
+                setTarget(0, 0);
+            });
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initTiltCards);
+    } else {
+        initTiltCards();
+    }
 })(jQuery);


### PR DESCRIPTION
## Summary
- replace the `[lm_loterie]` shortcode markup with a rich lottery card including badges, countdown, progress and CTA
- add comprehensive CSS for the 3D tilt card layout, gradients, badges and responsive behaviour
- introduce a lightweight JavaScript tilt animation with flash highlight on hover

## Testing
- php -l loterie-manager.php

------
https://chatgpt.com/codex/tasks/task_e_68cd266ff558832994e748e66d7f6bb4