### PR TITLE
Add lottery card mask and highlight CTA

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -211,6 +211,16 @@
     position: relative;
     overflow: hidden;
     border-radius: inherit;
+    --lm-card-mask: url('../img/lottery-card-mask.svg');
+    -webkit-mask-image: var(--lm-card-mask);
+    mask-image: var(--lm-card-mask);
+    -webkit-mask-size: cover;
+    mask-size: cover;
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-position: center;
+    mask-position: center;
+    background-color: rgba(15, 23, 42, 0.65);
 }
 
 .lm-lottery-card__media-ratio {
@@ -387,22 +397,25 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 0.4rem 1rem;
+    padding: 0.5rem 1.2rem;
     border-radius: 999px;
-    font-size: 0.75rem;
-    font-weight: 600;
+    font-size: 0.8rem;
+    font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.06em;
-    background: rgba(124, 58, 237, 0.2);
-    color: #ffffff;
+    letter-spacing: 0.08em;
+    background: linear-gradient(135deg, #f97316 0%, #facc15 100%);
+    color: #0f172a;
     text-decoration: none;
-    transition: background-color 0.2s ease, color 0.2s ease;
+    box-shadow: 0 12px 30px rgba(250, 204, 21, 0.35);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .lm-lottery-card__cta:hover,
 .lm-lottery-card__cta:focus {
-    background: rgba(124, 58, 237, 0.4);
-    color: #ffffff;
+    transform: translateY(-1px);
+    box-shadow: 0 16px 32px rgba(249, 115, 22, 0.4);
+    color: #0f172a;
+    outline: none;
 }
 
 .lm-lottery-card--featured {

--- a/assets/img/lottery-card-mask.svg
+++ b/assets/img/lottery-card-mask.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="fade" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#000" />
+      <stop offset="1" stop-color="#000" />
+    </linearGradient>
+  </defs>
+  <path fill="url(#fade)" d="M40,0 H360 C382,0 400,18 400,40 V220 C400,260 360,300 320,300 H80 C40,300 0,260 0,220 V60 C0,24 24,0 60,0 Z"/>
+</svg>

--- a/loterie-manager.php
+++ b/loterie-manager.php
@@ -138,7 +138,7 @@ if ( ! class_exists( 'Loterie_Manager' ) ) {
                 'loterie-manager-frontend',
                 plugins_url( 'assets/css/frontend.css', __FILE__ ),
                 array(),
-                '1.0.0'
+                '1.0.1'
             );
 
             wp_enqueue_script(


### PR DESCRIPTION
## Summary
- apply an SVG mask to lottery shortcode media blocks for stylised thumbnails
- brighten the "Participer" call-to-action with a bold gradient treatment and hover polish
- bump the frontend stylesheet version to ensure cache refresh

## Testing
- php -l loterie-manager.php

------
https://chatgpt.com/codex/tasks/task_e_68cdadcabc588329a5dfa89feff6ef3b