### PR TITLE
Remove lottery card mask entirely

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -211,15 +211,6 @@
     position: relative;
     overflow: hidden;
     border-radius: inherit;
-    --lm-card-mask: url('../img/lottery-card-mask.svg');
-    -webkit-mask-image: var(--lm-card-mask);
-    mask-image: var(--lm-card-mask);
-    -webkit-mask-size: cover;
-    mask-size: cover;
-    -webkit-mask-repeat: no-repeat;
-    mask-repeat: no-repeat;
-    -webkit-mask-position: center;
-    mask-position: center;
     background-color: rgba(15, 23, 42, 0.65);
 }
 

--- a/assets/img/lottery-card-mask.svg
+++ b/assets/img/lottery-card-mask.svg
@@ -1,9 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" preserveAspectRatio="xMidYMid slice">
-  <defs>
-    <linearGradient id="fade" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#000" />
-      <stop offset="1" stop-color="#000" />
-    </linearGradient>
-  </defs>
-  <path fill="url(#fade)" d="M40,0 H360 C382,0 400,18 400,40 V220 C400,260 360,300 320,300 H80 C40,300 0,260 0,220 V60 C0,24 24,0 60,0 Z"/>
-</svg>


### PR DESCRIPTION
## Summary
- remove the mask styling from the lottery card media container
- delete the unused lottery card mask SVG asset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce59d7ef448329b75340e1b75b8a52