### PR TITLE
Update lottery modal and order ticket display

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -63,18 +63,6 @@
 
             var description = $('<div>');
             description.append($('<strong>').text(lottery.title));
-            if (lottery.prize) {
-                description.append($('<div>').text(lottery.prize));
-            }
-
-            if (lottery.capacity) {
-                var soldText = lottery.sold ? lottery.sold : 0;
-                description.append($('<small>').text(soldText + ' / ' + lottery.capacity));
-            }
-
-            if (lottery.end_date) {
-                description.append($('<small>').text(lottery.end_date));
-            }
 
             option.append(checkbox).append(description);
             optionsWrapper.append(option);

--- a/loterie-manager.php
+++ b/loterie-manager.php
@@ -431,6 +431,10 @@ if ( ! class_exists( 'Loterie_Manager' ) ) {
                 return __( 'Loteries', 'loterie-manager' );
             }
 
+            if ( isset( $meta->key ) && 'lm_ticket_allocation' === $meta->key ) {
+                return __( 'Tickets', 'loterie-manager' );
+            }
+
             return $display_key;
         }
 
@@ -456,6 +460,58 @@ if ( ! class_exists( 'Loterie_Manager' ) ) {
                 }
 
                 return '';
+            }
+
+            if ( isset( $meta->key ) && 'lm_ticket_allocation' === $meta->key ) {
+                $allocation = intval( $meta->value );
+                if ( $allocation <= 0 ) {
+                    $allocation = 1;
+                }
+
+                $quantity = ( $item && method_exists( $item, 'get_quantity' ) ) ? intval( $item->get_quantity() ) : 1;
+                if ( $quantity <= 0 ) {
+                    $quantity = 1;
+                }
+
+                $tickets_total = max( 1, $allocation * $quantity );
+                $names         = $this->get_order_item_loterie_names( $item );
+
+                $names = array_map( static function ( $name ) {
+                    return sanitize_text_field( $name );
+                }, $names );
+
+                if ( empty( $names ) ) {
+                    return sprintf(
+                        _n( '%d ticket', '%d tickets', $tickets_total, 'loterie-manager' ),
+                        $tickets_total
+                    );
+                }
+
+                $names_list = implode( ', ', $names );
+
+                if ( count( $names ) === 1 ) {
+                    return sprintf(
+                        _n(
+                            '%1$d ticket pour la loterie : %2$s',
+                            '%1$d tickets pour la loterie : %2$s',
+                            $tickets_total,
+                            'loterie-manager'
+                        ),
+                        $tickets_total,
+                        $names_list
+                    );
+                }
+
+                return sprintf(
+                    _n(
+                        '%1$d ticket pour les loteries : %2$s',
+                        '%1$d tickets pour les loteries : %2$s',
+                        $tickets_total,
+                        'loterie-manager'
+                    ),
+                    $tickets_total,
+                    $names_list
+                );
             }
 
             return $display_value;


### PR DESCRIPTION
## Summary
- remove the extra lottery details in the selection modal so only the lottery name is shown
- show a descriptive ticket allocation message on order confirmations instead of the technical meta key

## Testing
- php -l loterie-manager.php

------
https://chatgpt.com/codex/tasks/task_e_68d8384e3b708329be3460ceb24321d3