### PR TITLE
Afficher les visuels de loterie non rognés dans l’e-mail de confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Lorsque les critères sont remplis (tickets valides disponibles et loterie prêt
 
 ## Historique des versions
 
+- **1.3.27** : utilisation des visuels complets (non rognés) dans l’e-mail de confirmation.
+- **1.3.26** : agrandissement des visuels de loterie dans l’e-mail de confirmation pour occuper la largeur disponible.
 - **1.3.25** : affichage du nombre de tickets par produit dans le panier/checkout et ajout du total de tickets dans l’e-mail de confirmation.
 - **1.3.24** : ajout des filtres `status`/`upcoming_date` pour cibler les loteries à venir avec/sans date et retrait du CSS frontend des shortcodes.
 - **1.3.23** : personnalisation du texte d’introduction de l’e-mail de confirmation de commande WooCommerce pour un ton plus chaleureux et rappel des loteries sélectionnées.

--- a/loterie-manager.php
+++ b/loterie-manager.php
@@ -3,7 +3,7 @@
 Plugin Name: WinShirt Loterie Manager
 Plugin URI: https://github.com/ShakassOne/loterie-winshirt
 Description: Gestion des loteries pour WooCommerce.
-Version: 1.3.25
+Version: 1.3.27
 Author: Shakass Communication
 Author URI: https://shakass.com
 Text Domain: loterie-winshirt
@@ -19,7 +19,7 @@ if ( ! class_exists( 'Loterie_Manager' ) ) {
 
     final class Loterie_Manager {
 
-        const VERSION = '1.3.25';
+        const VERSION = '1.3.27';
 
         /**
          * Meta key storing total ticket capacity for a loterie (post).
@@ -1398,18 +1398,10 @@ if ( ! class_exists( 'Loterie_Manager' ) ) {
             echo '<p style="margin:0 0 12px;font-weight:600;font-size:16px;color:#111;">' . esc_html( $heading ) . '</p>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
             echo '<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="width:100%;border-collapse:collapse;">'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
-            $index = 0;
-
             foreach ( $loteries as $loterie ) {
-                if ( 0 === $index % 3 ) {
-                    if ( 0 !== $index ) {
-                        echo '</tr>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                    }
+                echo '<tr>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
-                    echo '<tr>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                }
-
-                $cell_styles = 'padding:0 12px 12px 0;text-align:center;vertical-align:top;';
+                $cell_styles = 'padding:0 0 16px 0;text-align:left;vertical-align:top;';
                 echo '<td style="' . esc_attr( $cell_styles ) . '">'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
                 $link_open  = '';
@@ -1420,7 +1412,7 @@ if ( ! class_exists( 'Loterie_Manager' ) ) {
                     $link_close = '</a>';
                 }
 
-                $image_styles = 'display:block;border-radius:8px;width:120px;max-width:100%;height:auto;border:1px solid #e5e5e5;margin:0 auto 8px;';
+                $image_styles = 'display:block;border-radius:12px;width:100%;max-width:100%;height:auto;border:1px solid #e5e5e5;margin:0 0 8px;';
                 $image_html   = '';
 
                 if ( ! empty( $loterie['image_url'] ) ) {
@@ -1429,19 +1421,6 @@ if ( ! class_exists( 'Loterie_Manager' ) ) {
 
                 echo $link_open . $image_html . '<span style="display:block;font-size:13px;line-height:1.4;margin:0;color:#111;">' . esc_html( $loterie['title'] ) . '</span>' . $link_close; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
                 echo '</td>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-
-                $index++;
-            }
-
-            if ( 0 !== $index ) {
-                $remaining = $index % 3;
-
-                if ( 0 !== $remaining ) {
-                    for ( $i = $remaining; $i < 3; $i++ ) {
-                        echo '<td style="padding:0 12px 12px 0;"></td>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                    }
-                }
-
                 echo '</tr>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
             }
 
@@ -1563,7 +1542,7 @@ if ( ! class_exists( 'Loterie_Manager' ) ) {
                     $title = get_the_title( $post );
                     $title = '' !== $title ? wp_strip_all_tags( $title ) : sprintf( __( 'Loterie #%d', 'loterie-manager' ), $loterie_id );
 
-                    $image_url = get_the_post_thumbnail_url( $post, 'woocommerce_thumbnail' );
+                    $image_url = get_the_post_thumbnail_url( $post, 'full' );
 
                     if ( ! $image_url && function_exists( 'wc_placeholder_img_src' ) ) {
                         $image_url = wc_placeholder_img_src();


### PR DESCRIPTION
### Motivation

- Éviter que les miniatures des loteries dans l’e-mail de confirmation soient rognées tout en occupant la largeur disponible.
- Préserver le ratio d’origine des images et maximiser leur largeur sans les forcer en carré.
- Respecter la règle de versioning du projet en incrémentant la version du plugin.

### Description

- Remplacement de la taille de vignette utilisé par `get_the_post_thumbnail_url` de `'woocommerce_thumbnail'` à `'full'` pour récupérer l’image complète et éviter le rognage.
- Simplification du rendu HTML de l’e-mail pour afficher chaque loterie sur une ligne pleine largeur (suppression de la logique en grille 3 colonnes).
- Ajustement des styles d’image à `width:100%` et `height:auto` avec `border-radius:12px` pour occuper la largeur maximale tout en conservant le ratio d’origine.
- Bump de la version du plugin à `1.3.27` dans l’en-tête (`Version` et `const VERSION`) et ajout d’une entrée `1.3.27` dans `README.md`.

### Testing

- Aucun test automatisé exécuté pendant cette modification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f17e8725083299ba8e9577ed5990a)